### PR TITLE
fixed the bishop_spec test for horizontal move

### DIFF
--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Bishop', type: :model do
     end
 
     it 'returns false when bishop move horizontally' do
-      expect(@white_bishop.valid_move?(7, 8)).to eq(false)
+      expect(@white_bishop.valid_move?(6, 4)).to eq(false)
     end
 
     it 'returns true when bishop move diagonally' do


### PR DESCRIPTION
@dennisgit42 I noticed, when I was referencing your bishop_spec file to work on my queen_spec file, that the test for a horizontal move actually didn't test for a horizontal move, so I adjusted the new_x and new_y to reflect it.