### PR TITLE
installed pry-doc, to be able to examine Rails and Ruby documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   gem 'rubocop', require: false
   gem 'pry-rails'
   gem 'pry-stack_explorer'
+  gem 'pry-doc'
   # adding factory_girl gem to automate test data generation
   gem "factory_girl_rails", "~> 4.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-doc (0.11.1)
+      pry (~> 0.9)
+      yard (~> 0.9)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     pry-stack_explorer (0.4.9.2)
@@ -250,6 +253,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    yard (0.9.9)
 
 PLATFORMS
   ruby
@@ -266,6 +270,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   omniauth-facebook
   pg (~> 0.18)
+  pry-doc
   pry-rails
   pry-stack_explorer
   puma (~> 3.0)


### PR DESCRIPTION
This is a pull request only for installing a 'pry-doc' gem in the app, so we can dig deeper when debugging using pry. I've found having this gem to be useful. What do you guys think?