### PR TITLE
updated yard gem to fix vulnerable dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,7 +259,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    yard (0.9.9)
+    yard (0.9.12)
 
 PLATFORMS
   ruby
@@ -297,4 +297,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.15.3
+   1.16.0.pre.3


### PR DESCRIPTION
Dennis,
I saw this message on github and decided to try to fix the dependency.

You need to run 
$ bundle update yard
locally to update your own Gemfile.lock.

quoted from github:
We found a potential security vulnerability in one of your dependencies.
The yard dependency defined in Gemfile.lock has a known high severity security vulnerability in version range < 0.9.11 and should be updated.